### PR TITLE
Gemma4 fixes

### DIFF
--- a/src/cpp/src/continuous_batching/model_runner.hpp
+++ b/src/cpp/src/continuous_batching/model_runner.hpp
@@ -404,10 +404,11 @@ public:
         int64_t *input_ids_data = nullptr;
         int64_t *token_type_ids_data = nullptr;
 
-        // Collect token IDs for EMBEDDINGS decode step (for per-layer embeddings callback)
-        std::vector<int64_t> per_layer_input_ids_vec;
-        // Per-layer inputs for the current batch (Gemma4)
-        ov::Tensor per_layer_inputs_for_batch;
+        // Per-layer batch token IDs for Gemma4 per-layer embeddings (both prefill and decode)
+        std::function<ov::Tensor(const ov::Tensor&)> per_layer_cb;
+        if (m_inputs_embedder)
+            per_layer_cb = m_inputs_embedder->get_per_layer_embeddings_callback();
+        std::vector<int64_t> per_layer_batch_ids;
 
         ov::Tensor deepstack_visual_embeds;
         ov::Tensor visual_pos_masks;
@@ -582,35 +583,19 @@ public:
                         const auto& position_ids_elem = sequence->get_position_ids_list()[position_id];
                         const auto [begin, end] = Sequence::get_position_ids_elem_coordinates(position_ids_elem.get_shape(), position_ids_idx, false);
 
-                        // Collect token IDs for per-layer embeddings callback (decode phase)
-                        if (position_id >= prompt_len) {
-                            per_layer_input_ids_vec.push_back(sequence->get_generated_ids()[position_id - prompt_len]);
-                        }
-                        // Prefill: slice per_layer_inputs for this sequence group (pick current token rows)
-                        // Note: after SDPAToPagedAttention, inputs_embeds is [total_tokens, 1, hidden] (unsqueezed).
-                        // per_layer_inputs must match as [total_tokens, 1, n_layers, fdim] for correct element-wise add.
-                        // Stored per_layer_inputs is [1, full_seq, n_layers, fdim]; slice and transpose to [n_sched, 1, n_layers, fdim].
-                        if (position_id < prompt_len && !per_layer_inputs_for_batch && seq_idx == 0) {
-                            const ov::Tensor& stored_pli = sequence_group->get_per_layer_inputs();
-                            if (stored_pli.get_size() > 0 && stored_pli.get_shape().size() == 4) {
-                                const auto& sp = stored_pli.get_shape();
-                                size_t start_pos = group_position_id;
-                                size_t n_sched = std::min(num_scheduled_tokens, sp[1] > start_pos ? sp[1] - start_pos : size_t(0));
-                                size_t n_layers = sp[2], fdim = sp[3];
-                                // Slice stored_pli [1, full_seq, n_layers, fdim] -> transposed [n_sched, 1, n_layers, fdim]
-                                ov::Tensor transposed(stored_pli.get_element_type(), {n_sched, 1, n_layers, fdim});
-                                const float* src = stored_pli.data<const float>();
-                                float* dst = transposed.data<float>();
-                                size_t row_size = n_layers * fdim;
-                                for (size_t t = 0; t < n_sched; ++t) {
-                                    const float* src_row = src + (start_pos + t) * row_size;
-                                    float* dst_row = dst + t * row_size;
-                                    std::copy_n(src_row, row_size, dst_row);
-                                }
-                                per_layer_inputs_for_batch = transposed;
+                        // Collect token IDs for per-layer embeddings (Gemma4, both prefill and decode)
+                        if (per_layer_cb) {
+                            if (position_id < prompt_len) {
+                                // Prefill: use unified token IDs stored in sequence group
+                                const auto& pli_ids = sequence_group->get_per_layer_input_ids();
+                                per_layer_batch_ids.push_back(
+                                    position_id < pli_ids.size() ? pli_ids[position_id] : int64_t{0});
+                            } else {
+                                // Decode: use generated token ID
+                                per_layer_batch_ids.push_back(
+                                    sequence->get_generated_ids()[position_id - prompt_len]);
                             }
                         }
-
                         ov::Tensor dst_roi(position_ids, begin, end);
                         position_ids_elem.copy_to(dst_roi);
                     } else {
@@ -705,18 +690,16 @@ public:
                 m_request.set_tensor("token_type_ids", token_type_ids);
             }
 
-            // Set per-layer inputs (Gemma4)
-            if (!per_layer_input_ids_vec.empty() && m_inputs_embedder) {
-                // Decode step: compute per-layer embeddings via callback
-                auto per_layer_callback = m_inputs_embedder->get_per_layer_embeddings_callback();
-                if (per_layer_callback) {
-                    ov::Tensor decode_input_ids(ov::element::i64, {1, per_layer_input_ids_vec.size()},
-                                                per_layer_input_ids_vec.data());
-                    per_layer_inputs_for_batch = per_layer_callback(decode_input_ids);
-                }
-            }
-            if (per_layer_inputs_for_batch) {
-                try { m_request.set_tensor("per_layer_inputs", per_layer_inputs_for_batch); } catch (...) {}
+            // Set per-layer inputs (Gemma4) via callback for both prefill and decode
+            if (per_layer_cb && !per_layer_batch_ids.empty()) {
+                ov::Tensor cb_input(ov::element::i64, {1, per_layer_batch_ids.size()}, per_layer_batch_ids.data());
+                ov::Tensor pli = per_layer_cb(cb_input);
+                // Callback output is [1, n, n_layers, fdim]; PA model expects [n, 1, n_layers, fdim].
+                // Memory layout is identical so set_shape() is sufficient.
+                const auto& s = pli.get_shape();
+                if (s.size() == 4 && s[0] == 1 && s[1] > 1)
+                    pli.set_shape({s[1], s[0], s[2], s[3]});
+                try { m_request.set_tensor("per_layer_inputs", pli); } catch (...) {}
             }
             
             if (deepstack_context.have_deepstack_visual_inputs) {

--- a/src/cpp/src/continuous_batching/model_runner.hpp
+++ b/src/cpp/src/continuous_batching/model_runner.hpp
@@ -404,7 +404,6 @@ public:
         int64_t *input_ids_data = nullptr;
         int64_t *token_type_ids_data = nullptr;
 
-        // Per-layer batch token IDs for Gemma4 per-layer embeddings (both prefill and decode)
         std::function<ov::Tensor(const ov::Tensor&)> per_layer_cb;
         if (m_inputs_embedder)
             per_layer_cb = m_inputs_embedder->get_per_layer_embeddings_callback();
@@ -583,15 +582,12 @@ public:
                         const auto& position_ids_elem = sequence->get_position_ids_list()[position_id];
                         const auto [begin, end] = Sequence::get_position_ids_elem_coordinates(position_ids_elem.get_shape(), position_ids_idx, false);
 
-                        // Collect token IDs for per-layer embeddings (Gemma4, both prefill and decode)
                         if (per_layer_cb) {
                             if (position_id < prompt_len) {
-                                // Prefill: use unified token IDs stored in sequence group
                                 const auto& pli_ids = sequence_group->get_per_layer_input_ids();
                                 per_layer_batch_ids.push_back(
                                     position_id < pli_ids.size() ? pli_ids[position_id] : int64_t{0});
                             } else {
-                                // Decode: use generated token ID
                                 per_layer_batch_ids.push_back(
                                     sequence->get_generated_ids()[position_id - prompt_len]);
                             }

--- a/src/cpp/src/continuous_batching/model_runner.hpp
+++ b/src/cpp/src/continuous_batching/model_runner.hpp
@@ -404,6 +404,11 @@ public:
         int64_t *input_ids_data = nullptr;
         int64_t *token_type_ids_data = nullptr;
 
+        // Collect token IDs for EMBEDDINGS decode step (for per-layer embeddings callback)
+        std::vector<int64_t> per_layer_input_ids_vec;
+        // Per-layer inputs for the current batch (Gemma4)
+        ov::Tensor per_layer_inputs_for_batch;
+
         ov::Tensor deepstack_visual_embeds;
         ov::Tensor visual_pos_masks;
         bool *visual_pos_masks_data = nullptr;
@@ -577,6 +582,35 @@ public:
                         const auto& position_ids_elem = sequence->get_position_ids_list()[position_id];
                         const auto [begin, end] = Sequence::get_position_ids_elem_coordinates(position_ids_elem.get_shape(), position_ids_idx, false);
 
+                        // Collect token IDs for per-layer embeddings callback (decode phase)
+                        if (position_id >= prompt_len) {
+                            per_layer_input_ids_vec.push_back(sequence->get_generated_ids()[position_id - prompt_len]);
+                        }
+                        // Prefill: slice per_layer_inputs for this sequence group (pick current token rows)
+                        // Note: after SDPAToPagedAttention, inputs_embeds is [total_tokens, 1, hidden] (unsqueezed).
+                        // per_layer_inputs must match as [total_tokens, 1, n_layers, fdim] for correct element-wise add.
+                        // Stored per_layer_inputs is [1, full_seq, n_layers, fdim]; slice and transpose to [n_sched, 1, n_layers, fdim].
+                        if (position_id < prompt_len && !per_layer_inputs_for_batch && seq_idx == 0) {
+                            const ov::Tensor& stored_pli = sequence_group->get_per_layer_inputs();
+                            if (stored_pli.get_size() > 0 && stored_pli.get_shape().size() == 4) {
+                                const auto& sp = stored_pli.get_shape();
+                                size_t start_pos = group_position_id;
+                                size_t n_sched = std::min(num_scheduled_tokens, sp[1] > start_pos ? sp[1] - start_pos : size_t(0));
+                                size_t n_layers = sp[2], fdim = sp[3];
+                                // Slice stored_pli [1, full_seq, n_layers, fdim] -> transposed [n_sched, 1, n_layers, fdim]
+                                ov::Tensor transposed(stored_pli.get_element_type(), {n_sched, 1, n_layers, fdim});
+                                const float* src = stored_pli.data<const float>();
+                                float* dst = transposed.data<float>();
+                                size_t row_size = n_layers * fdim;
+                                for (size_t t = 0; t < n_sched; ++t) {
+                                    const float* src_row = src + (start_pos + t) * row_size;
+                                    float* dst_row = dst + t * row_size;
+                                    std::copy_n(src_row, row_size, dst_row);
+                                }
+                                per_layer_inputs_for_batch = transposed;
+                            }
+                        }
+
                         ov::Tensor dst_roi(position_ids, begin, end);
                         position_ids_elem.copy_to(dst_roi);
                     } else {
@@ -669,6 +703,20 @@ public:
             }
             if (have_token_type_ids && !m_cached_token_type_ids) {
                 m_request.set_tensor("token_type_ids", token_type_ids);
+            }
+
+            // Set per-layer inputs (Gemma4)
+            if (!per_layer_input_ids_vec.empty() && m_inputs_embedder) {
+                // Decode step: compute per-layer embeddings via callback
+                auto per_layer_callback = m_inputs_embedder->get_per_layer_embeddings_callback();
+                if (per_layer_callback) {
+                    ov::Tensor decode_input_ids(ov::element::i64, {1, per_layer_input_ids_vec.size()},
+                                                per_layer_input_ids_vec.data());
+                    per_layer_inputs_for_batch = per_layer_callback(decode_input_ids);
+                }
+            }
+            if (per_layer_inputs_for_batch) {
+                try { m_request.set_tensor("per_layer_inputs", per_layer_inputs_for_batch); } catch (...) {}
             }
             
             if (deepstack_context.have_deepstack_visual_inputs) {

--- a/src/cpp/src/sequence_group.hpp
+++ b/src/cpp/src/sequence_group.hpp
@@ -326,7 +326,7 @@ class SequenceGroup  : public std::enable_shared_from_this<SequenceGroup> {
 
     ov::Tensor m_deepstack_visual_embeds;
     std::optional<std::vector<bool>> m_visual_pos_masks;
-    ov::Tensor m_per_layer_inputs;  // Gemma4: per-layer text embeddings for prefill
+    std::vector<int64_t> m_per_layer_input_ids;  // Gemma4: unified token IDs for per-layer embeddings callback
 
     std::vector<float> m_prompt_log_probs;
     GenerationStream::Ptr m_generation_stream;
@@ -426,9 +426,8 @@ public:
                         tensor.copy_to(m_deepstack_visual_embeds);
                     } else if (input_name == "visual_pos_masks") {
                         m_visual_pos_masks = std::vector<bool>(tensor.data<const bool>(), tensor.data<const bool>() + tensor.get_size());
-                    } else if (input_name == "per_layer_inputs" && tensor.get_size() > 0) {
-                        m_per_layer_inputs = ov::Tensor(tensor.get_element_type(), tensor.get_shape());
-                        tensor.copy_to(m_per_layer_inputs);
+                    } else if (input_name == "per_layer_input_ids" && tensor.get_size() > 0) {
+                        m_per_layer_input_ids = std::vector<int64_t>(tensor.data<const int64_t>(), tensor.data<const int64_t>() + tensor.get_size());
                     }
                 }
             }
@@ -743,8 +742,8 @@ public:
         return m_visual_pos_masks;
     }
 
-    const ov::Tensor& get_per_layer_inputs() const {
-        return m_per_layer_inputs;
+    const std::vector<int64_t>& get_per_layer_input_ids() const {
+        return m_per_layer_input_ids;
     }
 
     size_t get_hidden_size() const {

--- a/src/cpp/src/sequence_group.hpp
+++ b/src/cpp/src/sequence_group.hpp
@@ -326,7 +326,7 @@ class SequenceGroup  : public std::enable_shared_from_this<SequenceGroup> {
 
     ov::Tensor m_deepstack_visual_embeds;
     std::optional<std::vector<bool>> m_visual_pos_masks;
-    std::vector<int64_t> m_per_layer_input_ids;  // Gemma4: unified token IDs for per-layer embeddings callback
+    std::vector<int64_t> m_per_layer_input_ids;
 
     std::vector<float> m_prompt_log_probs;
     GenerationStream::Ptr m_generation_stream;

--- a/src/cpp/src/sequence_group.hpp
+++ b/src/cpp/src/sequence_group.hpp
@@ -326,6 +326,7 @@ class SequenceGroup  : public std::enable_shared_from_this<SequenceGroup> {
 
     ov::Tensor m_deepstack_visual_embeds;
     std::optional<std::vector<bool>> m_visual_pos_masks;
+    ov::Tensor m_per_layer_inputs;  // Gemma4: per-layer text embeddings for prefill
 
     std::vector<float> m_prompt_log_probs;
     GenerationStream::Ptr m_generation_stream;
@@ -425,6 +426,9 @@ public:
                         tensor.copy_to(m_deepstack_visual_embeds);
                     } else if (input_name == "visual_pos_masks") {
                         m_visual_pos_masks = std::vector<bool>(tensor.data<const bool>(), tensor.data<const bool>() + tensor.get_size());
+                    } else if (input_name == "per_layer_inputs" && tensor.get_size() > 0) {
+                        m_per_layer_inputs = ov::Tensor(tensor.get_element_type(), tensor.get_shape());
+                        tensor.copy_to(m_per_layer_inputs);
                     }
                 }
             }
@@ -737,6 +741,10 @@ public:
     const std::optional<std::vector<bool>>& get_visual_pos_masks() const {
         OPENVINO_ASSERT(m_sequence_group_type == ov::genai::SequenceGroupType::EMBEDDINGS);
         return m_visual_pos_masks;
+    }
+
+    const ov::Tensor& get_per_layer_inputs() const {
+        return m_per_layer_inputs;
     }
 
     size_t get_hidden_size() const {

--- a/src/cpp/src/visual_language/gemma4/classes.cpp
+++ b/src/cpp/src/visual_language/gemma4/classes.cpp
@@ -315,9 +315,7 @@ std::pair<ov::Tensor, ov::Tensor> InputsEmbedderGemma4::get_inputs_embeds_with_t
 
     ov::Tensor input_ids = get_encoded_input_ids(prompt, metrics);
 
-    // Store unified input_ids for CB pipeline (avoids re-computing per chunk during chunked prefill)
     m_lm_extra_inputs["per_layer_input_ids"] = input_ids;
-    // Store full per_layer_inputs tensor for non-CB pipeline (lm_encoding.cpp uses it directly)
     m_lm_extra_inputs["per_layer_inputs"] = get_per_layer_embeddings(input_ids);
 
     CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());

--- a/src/cpp/src/visual_language/gemma4/classes.cpp
+++ b/src/cpp/src/visual_language/gemma4/classes.cpp
@@ -315,6 +315,9 @@ std::pair<ov::Tensor, ov::Tensor> InputsEmbedderGemma4::get_inputs_embeds_with_t
 
     ov::Tensor input_ids = get_encoded_input_ids(prompt, metrics);
 
+    // Store unified input_ids for CB pipeline (avoids re-computing per chunk during chunked prefill)
+    m_lm_extra_inputs["per_layer_input_ids"] = input_ids;
+    // Store full per_layer_inputs tensor for non-CB pipeline (lm_encoding.cpp uses it directly)
     m_lm_extra_inputs["per_layer_inputs"] = get_per_layer_embeddings(input_ids);
 
     CircularBufferQueueElementGuard<EmbeddingsRequest> embeddings_request_guard(m_embedding->get_request_queue().get());

--- a/src/cpp/src/visual_language/gemma4/classes.cpp
+++ b/src/cpp/src/visual_language/gemma4/classes.cpp
@@ -288,11 +288,25 @@ ov::Tensor InputsEmbedderGemma4::apply_chat_template_tokenize(const std::string&
     return IInputsEmbedder::apply_chat_template_tokenize(adjusted_prompt, metrics);
 }
 
+bool InputsEmbedderGemma4::has_token_type_ids() const {
+    return true;
+}
+
 ov::Tensor InputsEmbedderGemma4::get_inputs_embeds(const std::string& prompt,
                                                    const std::vector<EncodedImage>& images,
                                                    VLMPerfMetrics& metrics,
                                                    bool recalculate_merged_embeddings,
                                                    const std::vector<size_t>& images_sequence) {
+    return get_inputs_embeds_with_token_type_ids(prompt, images, metrics, recalculate_merged_embeddings, images_sequence).first;
+}
+
+std::pair<ov::Tensor, ov::Tensor> InputsEmbedderGemma4::get_inputs_embeds_with_token_type_ids(
+    const std::string& prompt,
+    const std::vector<EncodedImage>& images,
+    VLMPerfMetrics& metrics,
+    bool recalculate_merged_embeddings,
+    const std::vector<size_t>& images_sequence) {
+
     std::vector<ov::Tensor> image_embeds;
     image_embeds.reserve(images_sequence.size());
     for (size_t new_image_id : images_sequence) {
@@ -308,9 +322,12 @@ ov::Tensor InputsEmbedderGemma4::get_inputs_embeds(const std::string& prompt,
     ov::Tensor text_embeds = m_embedding->infer(req, input_ids);
 
     if (images.empty()) {
+        const size_t seq_len = text_embeds.get_shape()[1];
         ov::Tensor inputs_embeds(text_embeds.get_element_type(), text_embeds.get_shape());
         std::memcpy(inputs_embeds.data(), text_embeds.data(), text_embeds.get_byte_size());
-        return inputs_embeds;
+        ov::Tensor token_type_ids(ov::element::i64, {1, seq_len});
+        std::fill_n(token_type_ids.data<int64_t>(), seq_len, int64_t{0});
+        return {inputs_embeds, token_type_ids};
     }
 
     auto start_tokenizer_time = std::chrono::steady_clock::now();
@@ -322,9 +339,17 @@ ov::Tensor InputsEmbedderGemma4::get_inputs_embeds(const std::string& prompt,
         ov::genai::MicroSeconds(PerfMetrics::get_microsec(end_tokenizer_time - start_tokenizer_time));
     int64_t image_token_id = encoded_image_token.data<int64_t>()[encoded_image_token.get_size() - 1];
 
-    auto merged = utils::merge_text_and_image_embeddings_llava(input_ids, text_embeds, image_embeds, image_token_id);
+    auto inputs_embeds = utils::merge_text_and_image_embeddings_llava(input_ids, text_embeds, image_embeds, image_token_id);
 
-    return merged;
+    const int64_t* input_ids_data = input_ids.data<const int64_t>();
+    const size_t num_elements = input_ids.get_size();
+    ov::Tensor token_type_ids(ov::element::i64, input_ids.get_shape());
+    int64_t* token_type_data = token_type_ids.data<int64_t>();
+    for (size_t i = 0; i < num_elements; ++i) {
+        token_type_data[i] = (input_ids_data[i] == image_token_id) ? 1 : 0;
+    }
+
+    return {inputs_embeds, token_type_ids};
 }
 
 const std::unordered_map<std::string, ov::Tensor>& InputsEmbedderGemma4::get_lm_extra_inputs() const {

--- a/src/cpp/src/visual_language/gemma4/classes.hpp
+++ b/src/cpp/src/visual_language/gemma4/classes.hpp
@@ -38,6 +38,15 @@ public:
                                  bool recalculate_merged_embeddings = true,
                                  const std::vector<size_t>& image_sequence = {}) override;
 
+    std::pair<ov::Tensor, ov::Tensor> get_inputs_embeds_with_token_type_ids(
+        const std::string& prompt,
+        const std::vector<ov::genai::EncodedImage>& images,
+        ov::genai::VLMPerfMetrics& metrics,
+        bool recalculate_merged_embeddings = true,
+        const std::vector<size_t>& image_sequence = {}) override;
+
+    bool has_token_type_ids() const override;
+
     ov::Tensor apply_chat_template_tokenize(const std::string& prompt, ov::genai::VLMPerfMetrics& metrics) override;
 
     std::vector<ov::genai::EncodedImage> encode_images(const std::vector<ov::Tensor>& images) override;

--- a/src/cpp/src/visual_language/pipeline.cpp
+++ b/src/cpp/src/visual_language/pipeline.cpp
@@ -765,9 +765,7 @@ private:
 bool requires_sdpa(const std::filesystem::path& models_dir) {
     auto vlm_config = utils::from_config_json_if_exists<VLMConfig>(models_dir, "config.json");
     // TODO: remove it when GEMMA3 ticket-171180 is fixed
-    return vlm_config.model_type == VLMModelType::GEMMA3
-           // ticket: 183493
-           || vlm_config.model_type == VLMModelType::GEMMA4;
+    return vlm_config.model_type == VLMModelType::GEMMA3;
 }
 
 VLMPipeline::VLMPipeline(


### PR DESCRIPTION
- Set `per_layer_inputs` for Gemma4, which were not set for CB mode before
- Add `token_type_ids` for bidirectional image attention in CB mode
- This should be treated as an experimental CB mode enablement
- Depends on Roman's PR to optimum-intel + my patch to Roman's branch at https://github.com/rkazants/optimum-intel/pull/6